### PR TITLE
Add quotes around query so full query displays

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -58,7 +58,7 @@
   <div class="row" id="inputBar" style="margin:0 20%;">
     <div class="input-group" style="text-align:center" >
       {% if q %}
-        <input id="inputField" type="text" class="form-control" value = {{ q }}>
+        <input id="inputField" type="text" class="form-control" value = "{{ q }}">
       {% else %}
         <input id="inputField" type="text" class="form-control">
       {% endif %}


### PR DESCRIPTION
I quoted the Jinja `{{ q }}` call so that the full query displays, not simply the first word. This works well on my machine.

Thanks for writing this little app. It did its job well and the README was clear.